### PR TITLE
Move wishlist cta

### DIFF
--- a/guides/Overview.md
+++ b/guides/Overview.md
@@ -3,14 +3,3 @@
 Corvid's APIs empower you to take full control of your site’s functionality. Use the APIs to interact with site elements, your site’s database content, Wix Apps, and external services. The APIs also give you access to information about your site, its users, and more.
 
 To use the APIs, you’ll need a working knowledge of JavaScript, including ES2017 features. The APIs include lots of code examples to help you [get started](tutorials/getting-started).
-
-
-## Submit to the Corvid Wishlist
-
-As you work with Corvid, as great a product as it is, there's a chance you might come across something you wish we'd add to the product that we haven't gotten to - yet.
-
-To share your ideas with us head over to the [Wishlist page](https://www.wix.com/corvid/wishlist) of the Corvid site and let us know what you'd like to see added to our backlog.
-
-There you'll not only be able to add your own items, you can also vote on other user's ideas. You can also see the status of existing items so you'll have an idea of when new features will be ready for you to use.
-
-Our users' feedback is really important to us so please make use of this as often as you like and help us grow and improve to meet your needs.

--- a/guides/guides.json
+++ b/guides/guides.json
@@ -37,6 +37,11 @@
           "name": "External Services",
           "url": "./overview-external.md",
           "isMdFile": true
+        },
+        {
+          "name": "Submit to the Corvid Wishlist",
+          "url": "./wishlist.md",
+          "isMdFile": true
         }
       ]
     },

--- a/guides/wishlist.md
+++ b/guides/wishlist.md
@@ -1,0 +1,8 @@
+Submit to the Corvid Wishlist
+As you work with Corvid, as great a product as it is, there's a chance you might come across something you wish we'd add to the product that we haven't gotten to - yet.
+
+To share your ideas with us head over to the Wishlist page of the Corvid site and let us know what you'd like to see added to our backlog.
+
+There you'll not only be able to add your own items, you can also vote on other user's ideas. You can also see the status of existing items so you'll have an idea of when new features will be ready for you to use.
+
+Our users' feedback is really important to us so please make use of this as often as you like and help us grow and improve to meet your needs.

--- a/guides/wishlist.md
+++ b/guides/wishlist.md
@@ -1,3 +1,5 @@
+# Submit to the Corvid Wishlist
+
 As you work with Corvid, as great a product as it is, there's a chance you might come across something you wish we'd add to the product that we haven't gotten to - yet.
 
 To share your ideas with us head over to the [Wishlist page](https://www.wix.com/corvid/wishlist) of the Corvid site and let us know what you'd like to see added to our backlog.

--- a/guides/wishlist.md
+++ b/guides/wishlist.md
@@ -1,7 +1,6 @@
-Submit to the Corvid Wishlist
 As you work with Corvid, as great a product as it is, there's a chance you might come across something you wish we'd add to the product that we haven't gotten to - yet.
 
-To share your ideas with us head over to the Wishlist page of the Corvid site and let us know what you'd like to see added to our backlog.
+To share your ideas with us head over to the [Wishlist page](https://www.wix.com/corvid/wishlist) of the Corvid site and let us know what you'd like to see added to our backlog.
 
 There you'll not only be able to add your own items, you can also vote on other user's ideas. You can also see the status of existing items so you'll have an idea of when new features will be ready for you to use.
 


### PR DESCRIPTION
By request removing the wishlist CTA from the overview>intro page and making it its own page in the Overview section.