### PR TITLE
DocWorks for js-wixcode-sdk - no significant changes detected, but 6 …

### DIFF
--- a/js-wixcode-sdk/wix-window.service.json
+++ b/js-wixcode-sdk/wix-window.service.json
@@ -1,7 +1,6 @@
 { "name": "wix-window",
   "mixes": [],
-  "labels":
-    [ "changed" ],
+  "labels": [],
   "location":
     { "lineno": 14,
       "filename": "window.es6" },
@@ -115,8 +114,7 @@
         "extra":
           {  } },
       { "name": "locale",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "get": true,
         "set": false,
         "type": "string",


### PR DESCRIPTION
…issue detected

issues:
Operation postMessage has an unknown param type * (HtmlComponent.es6 (143))
Property value has mismatching types for get (string,number) and set (string) (TextInput.es6 (40, 76))
Property data has an unknown type * (HtmlComponentMessageEvent.es6 (26))
Operation routerSitemap has an unknown return type wix-router.WixRouterSitemapEntry (site.es6 (98))
Property value has an unknown type * (ValueMixin.es6 (62))
Property value has an unknown type * (ValueMixin.es6 (93))