### PR TITLE
Fix properties in example for wix-users register()

### DIFF
--- a/wixcode-users/wix-users.service.json
+++ b/wixcode-users/wix-users.service.json
@@ -445,8 +445,7 @@
         "extra":
           {  } },
       { "name": "getCurrentConsentPolicy",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params": [],
         "ret":
@@ -605,8 +604,7 @@
         "extra":
           {  } },
       { "name": "onConsentPolicyChanged",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "handler",
@@ -843,7 +841,8 @@
         "extra":
           {  } },
       { "name": "register",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "email",
@@ -938,14 +937,12 @@
                       "let firstName = // the user's first name",
                       "let lastName = // the user's last name",
                       "let phone =  // the user's phone number",
-                      "let nickname = // the user's nickname",
                       "",
                       "wixUsers.register(email, password, {",
                       "    contactInfo: {",
                       "        \"firstName\": firstName,",
                       "        \"lastName\": lastName,",
-                      "        \"phone\": phone,",
-                      "        \"nickname\": nickname",
+                      "        \"phones\": [phone]",
                       "    }",
                       "  } )",
                       "  .then( (result) => {",
@@ -958,8 +955,7 @@
         "extra":
           {  } },
       { "name": "resetConsentPolicy",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params": [],
         "ret":
@@ -1011,8 +1007,7 @@
         "extra":
           {  } },
       { "name": "setConsentPolicy",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "policy",
@@ -1163,8 +1158,7 @@
         "members": [],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "LoginOptions",
         "locations":
           [ { "lineno": 223,
@@ -1266,8 +1260,7 @@
               "doc": "Consent for a user's personal data to be transferred to a third party (such as Google Analytics, Facebook Pixel, and FullStory). The default is `true`." } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "PolicyDetails",
         "locations":
           [ { "lineno": 649,
@@ -1294,8 +1287,7 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "PolicyInfo",
         "locations":
           [ { "lineno": 635,


### PR DESCRIPTION
changes:
Service wix-users operation register.examples[2] has changed body

issues:
Message RegistrationOptions has an unknown property type wix-crm.ContactInfo (users.js (390))
Browserslist: caniuse-lite is outdated. Please run the following command: `npm update`