### PR TITLE
DocWorks for wixstore-client-worker - 2 changes detected, but 6 issue…

### DIFF
--- a/wixstore-client-worker/$w/CartIcon.service.json
+++ b/wixstore-client-worker/$w/CartIcon.service.json
@@ -3,7 +3,8 @@
   "mixes":
     [ "$w.Element",
       "$w.HiddenCollapsedMixin" ],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 202,
       "filename": "wixCodeDoc.js" },
@@ -306,11 +307,15 @@
           [ { "name": "choices",
               "type": "Object",
               "doc": "Product options to use when adding the\n product to the cart. The object contains key:value pairs where the key is the\n option name and the value is the chosen option value." },
-            { "name": "customTextField",
-              "type": "$w.CartIcon.AddToCartCustomTextField",
+            { "name": "customTextFields",
+              "type":
+                { "name": "Array",
+                  "typeParams":
+                    [ "$w.CartIcon.AddToCartCustomTextField" ] },
               "doc": "Custom custom\n text fields to use when adding the product to the cart." } ],
         "extra":
           {  },
-        "labels": [] } ],
+        "labels":
+          [ "changed" ] } ],
   "extra":
     {  } }


### PR DESCRIPTION
… detected

changes:
Service $w.CartIcon message AddToCartOptions member customTextField was removed
Service $w.CartIcon message AddToCartOptions has a new member customTextFields

issues:
Mixin $w.Element not found (wixCodeDoc.js (1))
Mixin $w.HiddenCollapsedMixin not found (wixCodeDoc.js (1))
Mixin $w.Element not found (wixCodeDoc.js (202))
Mixin $w.HiddenCollapsedMixin not found (wixCodeDoc.js (202))
Mixin $w.Element not found (wixCodeDoc.js (276))
Mixin $w.HiddenCollapsedMixin not found (wixCodeDoc.js (276))