### PR TITLE
Move isChangelog to Release Notes in guides.json

### DIFF
--- a/guides/guides.json
+++ b/guides/guides.json
@@ -42,7 +42,6 @@
           "name": "Submit to the Corvid Wishlist",
           "url": "./wishlist.md",
           "isMdFile": true,
-          "isChangelog": true
         }
       ]
     },
@@ -62,7 +61,8 @@
         {
           "name": "Release Notes",
           "url": "./release-notes.md",
-          "isMdFile": true
+          "isMdFile": true,
+          "isChangelog": true
         }
       ]
     } 


### PR DESCRIPTION
Looks like I added the `isChangelog` flag in a different guide than I intended.