### PR TITLE
DocWorks for platformized-filter-builder - 1 change detected, but 24 …

### DIFF
--- a/platformized-filter-builder/wix-data/WixDataFilter.service.json
+++ b/platformized-filter-builder/wix-data/WixDataFilter.service.json
@@ -1,7 +1,8 @@
 { "name": "WixDataFilter",
   "memberOf": "wix-data",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 5,
       "filename": "filterMixin.es6" },
@@ -388,7 +389,8 @@
         "extra":
           {  } },
       { "name": "endsWith",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "propertyName",
@@ -396,7 +398,7 @@
               "doc": "The property whose value will be compared with the string." },
             { "name": "string",
               "type": "string",
-              "doc": "The string to look for at the beginning of the specified property value." } ],
+              "doc": "The string to look for at the end of the specified property value." } ],
         "ret":
           { "type": "wix-data.WixDataQuery",
             "doc": "A `WixDataQuery` object representing the refined query." },


### PR DESCRIPTION
…issue detected

changes:
Service wix-data.WixDataFilter operation endsWith has changed param string doc

issues:
Operation eq has an unknown param type * (filterMixin.es6 (43))
Operation eq has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (43))
Operation ne has an unknown param type * (filterMixin.es6 (72))
Operation ne has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (72))
Operation ge has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (101))
Operation gt has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (141))
Operation le has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (178))
Operation lt has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (218))
Operation isNotEmpty has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (255))
Operation isEmpty has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (287))
Operation startsWith has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (320))
Operation endsWith has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (347))
Operation contains has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (374))
Operation hasSome has an unknown param type * (filterMixin.es6 (403))
Operation hasSome has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (403))
Operation hasAll has an unknown param type * (filterMixin.es6 (444))
Operation hasAll has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (444))
Operation or has an unknown param type wix-data.WixDataQuery (filterMixin.es6 (479))
Operation or has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (479))
Operation and has an unknown param type wix-data.WixDataQuery (filterMixin.es6 (518))
Operation and has an unknown return type wix-data.WixDataQuery (filterMixin.es6 (518))
Operation not has an unknown param type wix-data.W ...