### PR TITLE
change QueryOptions to AuthOptions

### DIFF
--- a/wix-crm-backend/wix-crm-backend.service.json
+++ b/wix-crm-backend/wix-crm-backend.service.json
@@ -1,7 +1,6 @@
 { "name": "wix-crm-backend",
   "mixes": [],
-  "labels":
-    [ "changed" ],
+  "labels": [],
   "location":
     { "lineno": 1,
       "filename": "contacts.js" },
@@ -251,8 +250,7 @@
         "extra":
           {  } },
       { "name": "emailContact",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "emailId",

--- a/wix-crm-backend/wix-crm-backend/Contacts.service.json
+++ b/wix-crm-backend/wix-crm-backend/Contacts.service.json
@@ -1,8 +1,7 @@
 { "name": "Contacts",
   "memberOf": "wix-crm-backend",
   "mixes": [],
-  "labels":
-    [ "changed" ],
+  "labels": [],
   "location":
     { "lineno": 5,
       "filename": "index.js" },
@@ -1488,8 +1487,7 @@
         "extra":
           {  } },
       { "name": "queryContacts",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params": [],
         "ret":

--- a/wix-crm-backend/wix-crm-backend/Contacts/ContactsQueryBuilder.service.json
+++ b/wix-crm-backend/wix-crm-backend/Contacts/ContactsQueryBuilder.service.json
@@ -1,7 +1,8 @@
 { "name": "ContactsQueryBuilder",
   "memberOf": "wix-crm-backend.Contacts",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 16,
       "filename": "queryContacts.js" },
@@ -449,12 +450,13 @@
         "extra":
           {  } },
       { "name": "find",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "options",
               "type": "wix-crm-backend.Contacts.QueryOptions",
-              "doc": "The `options` parameter is an optional parameter that can be used when calling the query [`find()`](#find) function.",
+              "doc": "Search and authorization options.",
               "optional": true } ],
         "ret":
           { "type":

--- a/wix-crm-backend/wix-crm-backend/Contacts/ExtendedFieldsQueryBuilder.service.json
+++ b/wix-crm-backend/wix-crm-backend/Contacts/ExtendedFieldsQueryBuilder.service.json
@@ -189,7 +189,7 @@
         "params":
           [ { "name": "options",
               "type": "wix-crm-backend.Contacts.AuthOptions",
-              "doc": "The `options` parameter is an optional parameter that can be used when calling the query [`find()`](#find) function.",
+              "doc": "Authorization options.",
               "optional": true } ],
         "ret":
           { "type":

--- a/wix-crm-backend/wix-crm-backend/Contacts/ExtendedFieldsQueryBuilder.service.json
+++ b/wix-crm-backend/wix-crm-backend/Contacts/ExtendedFieldsQueryBuilder.service.json
@@ -1,7 +1,8 @@
 { "name": "ExtendedFieldsQueryBuilder",
   "memberOf": "wix-crm-backend.Contacts",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 1,
       "filename": "queryExtendedFields.js" },
@@ -182,11 +183,12 @@
         "extra":
           {  } },
       { "name": "find",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "options",
-              "type": "wix-crm-backend.Contacts.QueryOptions",
+              "type": "wix-crm-backend.Contacts.AuthOptions",
               "doc": "The `options` parameter is an optional parameter that can be used when calling the query [`find()`](#find) function.",
               "optional": true } ],
         "ret":

--- a/wix-crm-backend/wix-crm-backend/Contacts/LabelsQueryBuilder.service.json
+++ b/wix-crm-backend/wix-crm-backend/Contacts/LabelsQueryBuilder.service.json
@@ -189,7 +189,7 @@
         "params":
           [ { "name": "options",
               "type": "wix-crm-backend.Contacts.AuthOptions",
-              "doc": "The `options` parameter is an optional parameter that can be used when calling the query [`find()`](#find) function.",
+              "doc": "Authorization options.",
               "optional": true } ],
         "ret":
           { "type":

--- a/wix-crm-backend/wix-crm-backend/Contacts/LabelsQueryBuilder.service.json
+++ b/wix-crm-backend/wix-crm-backend/Contacts/LabelsQueryBuilder.service.json
@@ -1,7 +1,8 @@
 { "name": "LabelsQueryBuilder",
   "memberOf": "wix-crm-backend.Contacts",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 1,
       "filename": "queryLabels.js" },
@@ -182,11 +183,12 @@
         "extra":
           {  } },
       { "name": "find",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "options",
-              "type": "wix-crm-backend.Contacts.QueryOptions",
+              "type": "wix-crm-backend.Contacts.AuthOptions",
               "doc": "The `options` parameter is an optional parameter that can be used when calling the query [`find()`](#find) function.",
               "optional": true } ],
         "ret":


### PR DESCRIPTION
original pr https://github.com/wix-private/velo-docs/pull/41

changes:
Service wix-crm-backend.Contacts.ExtendedFieldsQueryBuilder operation find has changed param options type
Service wix-crm-backend.Contacts.LabelsQueryBuilder operation find has changed param options type

issues:
Operation eq has an unknown param type * (queryContacts.js (44))
Operation ne has an unknown param type * (queryContacts.js (87))
Operation emailContact has an unknown param type wix-users.TriggeredEmailOptions (contacts.js (88))
Operation emailContact has an unknown param type wix-users.TriggeredEmailOptions (contacts.js (88))