### PR TITLE
DocWorks for wix-data-core - 1 change detected, but 7 issue detected

### DIFF
--- a/wix-data-core/wix-data.service.json
+++ b/wix-data-core/wix-data.service.json
@@ -430,8 +430,7 @@
         "extra":
           {  } },
       { "name": "bulkRemove",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "collectionId",
@@ -1409,8 +1408,7 @@
         "extra":
           {  } },
       { "name": "insertReference",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "collectionId",
@@ -1789,7 +1787,8 @@
         "extra":
           {  } },
       { "name": "queryReferenced",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "collectionId",
@@ -1805,7 +1804,8 @@
               "doc": "The property that contains the references to the referenced items." },
             { "name": "options",
               "type": "wix-data.WixDataQueryReferencedOptions",
-              "doc": "An object for controlling the order of the returned referenced items." } ],
+              "doc": "An object for controlling the order of the returned referenced items.",
+              "optional": true } ],
         "ret":
           { "type":
               { "name": "Promise",


### PR DESCRIPTION
changes:
Service wix-data operation queryReferenced has changed param options doc

issues:
Operation filter has an unknown param type wix-data.WixDataFilter (aggregate.es6 (52))
Operation having has an unknown param type wix-data.WixDataFilter (aggregate.es6 (153))
Operation onFailure has an unknown param type Error (hooks.es6 (486))
Mixin wix-data.WixDataFilter not found (query.es6 (8))
Operation filter has an unknown return type wix-data.WixDataFilter (data-api.es6 (327))
Message WixDataBulkRemoveResult has an unknown property type Error (data-api.es6 (449))
Message WixDataBulkResult has an unknown property type Error (data-api.es6 (924))