### PR TITLE
[backend-stores-product] - inStock and visible removed from write functions, and params in example

### DIFF
--- a/wix-stores-backend/wix-stores-backend.service.json
+++ b/wix-stores-backend/wix-stores-backend.service.json
@@ -43,7 +43,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the media are added to the product.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 600,
+          [ { "lineno": 604,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Adds media items by ID to a product.",
@@ -123,7 +123,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the media items are added to the product options.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 619,
+          [ { "lineno": 623,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Adds media items by ID to product options.",
@@ -191,7 +191,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the products are added to the product collection.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 516,
+          [ { "lineno": 520,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Adds products by ID to a product collection.",
@@ -921,7 +921,8 @@
         "extra":
           {  } },
       { "name": "createProduct",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "productInfo",
@@ -934,7 +935,7 @@
                   [ "wix-stores-backend.Product" ] },
             "doc": "Fulfilled - The created product.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 448,
+          [ { "lineno": 452,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Creates a new product.",
@@ -989,15 +990,11 @@
                       "    \"Weight\": {",
                       "      \"choices\": [{",
                       "        \"value\": \"250g\",",
-                      "        \"description\": \"250g\",",
-                      "        \"inStock\": true,",
-                      "        \"visible\": true",
+                      "        \"description\": \"250g\"",
                       "      },",
                       "      {",
                       "        \"value\": \"500g\",",
-                      "        \"description\": \"500g\",",
-                      "        \"inStock\": true,",
-                      "        \"visible\": true",
+                      "        \"description\": \"500g\"",
                       "      }",
                       "      ]",
                       "    }",
@@ -1626,7 +1623,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the product is deleted.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 470,
+          [ { "lineno": 474,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Deletes an existing product.",
@@ -1668,7 +1665,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the options are deleted.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 503,
+          [ { "lineno": 507,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Deletes all options for an existing product.",
@@ -2189,7 +2186,7 @@
                   [ "wix-stores-backend.ProductOptionsAvailability" ] },
             "doc": "Fulfilled - The availability information of the product." },
         "locations":
-          [ { "lineno": 297,
+          [ { "lineno": 301,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Gets the availability of a product based on the specified option choices.",
@@ -2410,7 +2407,7 @@
                         [ "wix-stores-backend.VariantItem" ] } ] },
             "doc": "Fulfilled - The variants with the specified choices." },
         "locations":
-          [ { "lineno": 433,
+          [ { "lineno": 437,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Gets a product's available variants based on the specified product ID and either option choices or variant IDs.",
@@ -2682,7 +2679,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the media items are removed from the product.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 635,
+          [ { "lineno": 639,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Removes media items by ID from a product.",
@@ -2761,7 +2758,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the media items are removed from the product options.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 658,
+          [ { "lineno": 662,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Removes media items by ID from a product's options.",
@@ -2834,7 +2831,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the products are removed from the collection.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 535,
+          [ { "lineno": 539,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Removes products by ID from a collection.",
@@ -2900,7 +2897,7 @@
                   [ "void" ] },
             "doc": "Fulfilled - When the variant data are reset.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 583,
+          [ { "lineno": 587,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Resets the data (such as the price and the weight) of all variants for a given product to their default values.",
@@ -3724,7 +3721,7 @@
                   [ "wix-stores-backend.Product" ] },
             "doc": "Fulfilled - The updated product.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 483,
+          [ { "lineno": 487,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Updates an existing product by ID.",
@@ -3781,7 +3778,7 @@
                   [ "wix-stores-backend.VariantItem" ] },
             "doc": "Fulfilled - The updated variant.\nRejected - Error message." },
         "locations":
-          [ { "lineno": 556,
+          [ { "lineno": 560,
               "filename": "products.js" } ],
         "docs":
           { "summary": "Updates the data (such as the price and the weight) of an existing product variant in the store.",
@@ -7303,7 +7300,7 @@
         "labels": [] },
       { "name": "Choice",
         "locations":
-          [ { "lineno": 416,
+          [ { "lineno": 420,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing the choice for a product variant.",
@@ -7320,7 +7317,7 @@
         "labels": [] },
       { "name": "Choices",
         "locations":
-          [ { "lineno": 425,
+          [ { "lineno": 429,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing the choice for a product variant.",
@@ -12181,7 +12178,7 @@
         "labels": [] },
       { "name": "Media",
         "locations":
-          [ { "lineno": 406,
+          [ { "lineno": 410,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing the media item for a product.",
@@ -12241,7 +12238,7 @@
         "labels": [] },
       { "name": "MediaChoice",
         "locations":
-          [ { "lineno": 397,
+          [ { "lineno": 401,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing the media item for a product's choices.",
@@ -14552,8 +14549,7 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "OrderTotals",
         "locations":
           [ { "lineno": 140,
@@ -14756,7 +14752,7 @@
         "labels": [] },
       { "name": "PagingOptions",
         "locations":
-          [ { "lineno": 351,
+          [ { "lineno": 355,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing paging options.",
@@ -15140,15 +15136,11 @@
                       "    \"Weight\": {",
                       "      \"choices\": [{",
                       "        \"value\": \"250g\",",
-                      "        \"description\": \"250g\",",
-                      "        \"inStock\": true,",
-                      "        \"visible\": true",
+                      "        \"description\": \"250g\"",
                       "      },",
                       "      {",
                       "        \"value\": \"500g\",",
-                      "        \"description\": \"500g\",",
-                      "        \"inStock\": true,",
-                      "        \"visible\": true",
+                      "        \"description\": \"500g\"",
                       "      }",
                       "      ]",
                       "    }",
@@ -15426,7 +15418,8 @@
               "doc": "Price per unit formatted with currency symbol." } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "ProductAdditionalInfoSection",
         "locations":
           [ { "lineno": 133,
@@ -15450,7 +15443,7 @@
         "labels": [] },
       { "name": "ProductChoices",
         "locations":
-          [ { "lineno": 331,
+          [ { "lineno": 335,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing a product variant's option choices.",
@@ -15614,11 +15607,12 @@
               "type":
                 { "name": "Array",
                   "typeParams":
-                    [ "wix-stores-backend.ProductOptionsChoice" ] },
+                    [ "wix-stores-backend.ProductOptionsChoiceInfo" ] },
               "doc": "Option choices.\n Each option can contain between one and thirty choices." } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
       { "name": "ProductOptions",
         "locations":
           [ { "lineno": 216,
@@ -15638,7 +15632,7 @@
         "labels": [] },
       { "name": "ProductOptionsAvailability",
         "locations":
-          [ { "lineno": 269,
+          [ { "lineno": 273,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object returned by the `getProductOptionsAvailability()` function representing the availability of a product.",
@@ -15749,7 +15743,7 @@
         "labels": [] },
       { "name": "ProductOptionsAvailabilitySelectedVariant",
         "locations":
-          [ { "lineno": 281,
+          [ { "lineno": 285,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing the product variant selected using the `getProductOptionsAvailability()` function.",
@@ -15885,7 +15879,7 @@
         "labels": [] },
       { "name": "ProductOptionsChoice",
         "locations":
-          [ { "lineno": 260,
+          [ { "lineno": 264,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing an options choice for a store product, such as choice \"Small\" for the option \"Size.\"",
@@ -15902,13 +15896,34 @@
               "doc": "Choice description." },
             { "name": "inStock",
               "type": "boolean",
-              "doc": "Indicates whether the product with this choice is in stock. When adding a product, this property is read-only." },
+              "doc": "Whether the product with this choice is in stock." },
             { "name": "visible",
               "type": "boolean",
-              "doc": "Indicates whether the product with this option is visible.  When adding a product, this property is read-only." } ],
+              "doc": "Whether the product with this option is visible." } ],
         "extra":
           {  },
-        "labels": [] },
+        "labels":
+          [ "changed" ] },
+      { "name": "ProductOptionsChoiceInfo",
+        "locations":
+          [ { "lineno": 258,
+              "filename": "products.js" } ],
+        "docs":
+          { "links": [],
+            "examples": [],
+            "extra":
+              {  } },
+        "members":
+          [ { "name": "value",
+              "type": "number",
+              "doc": "Choice value." },
+            { "name": "description",
+              "type": "number",
+              "doc": "Choice description." } ],
+        "extra":
+          {  },
+        "labels":
+          [ "new" ] },
       { "name": "ProductOptionsInfo",
         "locations":
           [ { "lineno": 231,
@@ -15946,7 +15961,7 @@
         "labels": [] },
       { "name": "ProductVariantOptions",
         "locations":
-          [ { "lineno": 342,
+          [ { "lineno": 346,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing the selection of specific variants of a product. Use only one of\n `choices` or `variantIds`.",
@@ -17669,7 +17684,7 @@
         "labels": [] },
       { "name": "VariantData",
         "locations":
-          [ { "lineno": 368,
+          [ { "lineno": 372,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object containing variant information.",
@@ -17792,7 +17807,7 @@
         "labels": [] },
       { "name": "VariantInfo",
         "locations":
-          [ { "lineno": 383,
+          [ { "lineno": 387,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object containing variant information for update.",
@@ -17909,7 +17924,7 @@
         "labels": [] },
       { "name": "VariantItem",
         "locations":
-          [ { "lineno": 359,
+          [ { "lineno": 363,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing a product variant item.",
@@ -17933,7 +17948,7 @@
         "labels": [] },
       { "name": "Variants",
         "locations":
-          [ { "lineno": 678,
+          [ { "lineno": 682,
               "filename": "products.js" } ],
         "docs":
           { "summary": "An object representing product variants.",


### PR DESCRIPTION
…ected

changes:
Service wix-stores-backend operation createProduct.examples[0] has changed body
Service wix-stores-backend message Product.examples[0] has changed body
Service wix-stores-backend message ProductOptionInfo member choices has changed type
Service wix-stores-backend message ProductOptionsChoice member inStock has changed doc
Service wix-stores-backend message ProductOptionsChoice member visible has changed doc
Service wix-stores-backend has a new message ProductOptionsChoiceInfo

issues:
Message ProductCreatedEvent has an unknown property type $w.Gallery.VideoItem (events.js (223))
Message SeoTag has an unknown property type object (products.js (91))
Message SeoTag has an unknown property type object (products.js (91))
Message SeoTag has an unknown property type object (products.js (91))
Message SeoTag has an unknown property type object (products.js (91))