### PR TITLE
DocWorks for js-wixcode-sdk - 1 change detected, but 7 issue detected

### DIFF
--- a/js-wixcode-sdk/$w/UploadButton.service.json
+++ b/js-wixcode-sdk/$w/UploadButton.service.json
@@ -7,7 +7,8 @@
       "$w.FocusMixin",
       "$w.StyleMixin",
       "$w.RequiredMixin" ],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 154,
       "filename": "UploadButton.es6" },
@@ -78,10 +79,11 @@
         "extra":
           {  } },
       { "name": "fileLimit",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "get": true,
         "set": true,
-        "type": "string",
+        "type": "number",
         "locations":
           [ { "lineno": 252,
               "filename": "UploadButton.es6" },


### PR DESCRIPTION
changes:
Service $w.UploadButton property fileLimit has changed type

issues:
Operation postMessage has an unknown param type * (HtmlComponent.es6 (145))
Property fileLimit has mismatching types for get (number) and set (string) (UploadButton.es6 (252, 271))
Property data has an unknown type * (HtmlComponentMessageEvent.es6 (26))
Operation routerSitemap has an unknown return type wix-router.WixRouterSitemapEntry (site.es6 (98))
Property value has an unknown type * (ValueMixin.es6 (87))
Property value has an unknown type * (ValueMixin.es6 (118))
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating