### PR TITLE
DocWorks for wix-pricing-plans-backend - 2 changes detected, but 3 is…

### DIFF
--- a/wix-pricing-plans-backend/wix-pricing-plans-backend.service.json
+++ b/wix-pricing-plans-backend/wix-pricing-plans-backend.service.json
@@ -681,7 +681,8 @@
         "extra":
           {  } },
       { "name": "listPlans",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "planIds",
@@ -701,7 +702,7 @@
                 "typeParams":
                   [ { "name": "Array",
                       "typeParams":
-                        [ "wix-pricing-plans-backend.Plan" ] } ] },
+                        [ "wix-pricing-plans-backend.Plans" ] } ] },
             "doc": "Fulfilled - List of plans that match the given criteria." },
         "locations":
           [ { "lineno": 18,
@@ -786,7 +787,8 @@
         "extra":
           {  } },
       { "name": "listPublicPlans",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "planIds",
@@ -806,7 +808,7 @@
                 "typeParams":
                   [ { "name": "Array",
                       "typeParams":
-                        [ "wix-pricing-plans-backend.PublicPlan" ] } ] },
+                        [ "wix-pricing-plans-backend.PublicPlans" ] } ] },
             "doc": "Fulfilled - List of public pricing plans." },
         "locations":
           [ { "lineno": 8,
@@ -944,8 +946,7 @@
         "extra":
           {  } },
       { "name": "queryPublicPlans",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params": [],
         "ret":


### PR DESCRIPTION
…sue detected

changes:
Service wix-pricing-plans-backend operation listPlans has changed return type
Service wix-pricing-plans-backend operation listPublicPlans has changed return type

issues:
Operation eq has an unknown param type * (PublicPlansQueryBuilder.js (43))
Operation ne has an unknown param type * (PublicPlansQueryBuilder.js (72))
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating