### PR TITLE
DocWorks for js-wixcode-sdk - 1 change detected, but 7 issue detected

### DIFF
--- a/js-wixcode-sdk/$w/UploadButton.service.json
+++ b/js-wixcode-sdk/$w/UploadButton.service.json
@@ -7,8 +7,7 @@
       "$w.FocusMixin",
       "$w.StyleMixin",
       "$w.RequiredMixin" ],
-  "labels":
-    [ "changed" ],
+  "labels": [],
   "location":
     { "lineno": 154,
       "filename": "UploadButton.es6" },
@@ -375,8 +374,7 @@
         "extra":
           {  } },
       { "name": "startUpload",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params": [],
         "ret":

--- a/js-wixcode-sdk/$w/VideoBox.service.json
+++ b/js-wixcode-sdk/$w/VideoBox.service.json
@@ -3,7 +3,8 @@
   "mixes":
     [ "$w.Element",
       "$w.HiddenCollapsedMixin" ],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 19,
       "filename": "VideoBox.es6" },
@@ -117,12 +118,15 @@
         "extra":
           {  } },
       { "name": "src",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "get": true,
-        "set": false,
+        "set": true,
         "type": "string",
         "locations":
           [ { "lineno": 604,
+              "filename": "VideoBox.es6" },
+            { "lineno": 637,
               "filename": "VideoBox.es6" } ],
         "docs":
           { "summary": "Sets or gets the file location of the current video.",


### PR DESCRIPTION
changes:
Service $w.VideoBox property src has changed setter

issues:
Operation postMessage has an unknown param type * (HtmlComponent.es6 (145))
Property fileLimit has mismatching types for get (number) and set (string) (UploadButton.es6 (252, 272))
Property data has an unknown type * (HtmlComponentMessageEvent.es6 (26))
Operation routerSitemap has an unknown return type wix-router.WixRouterSitemapEntry (site.es6 (98))
Property value has an unknown type * (ValueMixin.es6 (87))
Property value has an unknown type * (ValueMixin.es6 (118))
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating