### PR TITLE
[wix-backend-media-manager] fix bug listFiles, listFolders

### DIFF
--- a/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
+++ b/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
@@ -146,8 +146,7 @@
         "extra":
           {  } },
       { "name": "getFolderInfo",
-        "labels":
-          [ "new" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "folderId",
@@ -394,8 +393,7 @@
         "extra":
           {  } },
       { "name": "importFile",
-        "labels":
-          [ "changed" ],
+        "labels": [],
         "nameParams": [],
         "params":
           [ { "name": "path",
@@ -478,18 +476,21 @@
           {  } },
       { "name": "listFiles",
         "labels":
-          [ "new" ],
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "filters",
               "type": "wix-media-backend.MediaManager.FileFilterOptions",
-              "doc": "File filter options." },
-            { "name": "sort",
+              "doc": "File filter options.",
+              "optional": true },
+            { "name": "sorting",
               "type": "wix-media-backend.MediaManager.SortingOptions",
-              "doc": "Sorting options." },
-            { "name": "pagination",
-              "type": "wix-media-backend.MediaManager.PaginationOptions",
-              "doc": "Pagination options." } ],
+              "doc": "Sorting options.",
+              "optional": true },
+            { "name": "paging",
+              "type": "wix-media-backend.MediaManager.PagingOptions",
+              "doc": "Paging options.",
+              "optional": true } ],
         "ret":
           { "type":
               { "name": "Promise",
@@ -507,7 +508,10 @@
               [ "The `listFiles()` function returns a Promise that resolves to information about",
                 " the files in the folder.",
                 "",
-                " To get a list of files within a specific folder in the Media Manager, pass the folder's ID in the `parentFolderId` parameter. If no folder is specified, the `listFiles()` function returns the list of files in the root folder of the Media Manager." ],
+                " To get a list of files within a specific folder in the Media Manager, pass the folder's ID in the `parentFolderId` parameter. If no folder is specified, the `listFiles()` function returns the list of files in the root folder of the Media Manager. ",
+                "",
+                " **Note:** This function's parameters are positional, and must be specified in the sequence shown in the syntax below. When specifying a parameter, use 'null' as a placeholder for any unspecified parameters. ",
+                " For example, to specify `sorting`, call `listFiles(null, sorting, null)`." ],
             "links": [],
             "examples":
               [ { "title": "List files in a specified folder",
@@ -519,7 +523,7 @@
                       "};",
                       "",
                       "export function myListFilesFunction() {",
-                      "  return mediaManager.listFiles(filters)",
+                      "  return mediaManager.listFiles(filters, null, null)",
                       "    .then((myFiles) => {",
                       "      const originalFileName = myFiles[0].originalFileName;",
                       "      const fileName = myFiles[1].fileName;",
@@ -728,18 +732,21 @@
           {  } },
       { "name": "listFolders",
         "labels":
-          [ "new" ],
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "filters",
               "type": "wix-media-backend.MediaManager.FolderFilterOptions",
-              "doc": "Folder filter options." },
-            { "name": "sort",
-              "type": "wix-media-backend.MediaManager.SortOptions",
-              "doc": "Sorting options." },
-            { "name": "pagination",
-              "type": "wix-media-backend.MediaManager.PaginationOptions",
-              "doc": "Pagination options." } ],
+              "doc": "Folder filter options.",
+              "optional": true },
+            { "name": "sorting",
+              "type": "wix-media-backend.MediaManager.SortingOptions",
+              "doc": "Sorting options.",
+              "optional": true },
+            { "name": "paging",
+              "type": "wix-media-backend.MediaManager.PagingOptions",
+              "doc": "Paging options.",
+              "optional": true } ],
         "ret":
           { "type":
               { "name": "Promise",
@@ -757,7 +764,10 @@
               [ "The `listFolders()` function returns a Promise that resolves to information about",
                 " the folders in the folder.",
                 "",
-                " To get a list of folders within a specific folder in the Media Manager, pass the folder's ID in the `parentFolderId` parameter. If no folder is specified, the `listFolders()` function returns the list of folders in the root folder of the Media Manager." ],
+                " To get a list of folders within a specific folder in the Media Manager, pass the folder's ID in the `parentFolderId` parameter. If no folder is specified, the `listFolders()` function returns the list of folders in the root folder of the Media Manager.",
+                " ",
+                " **Note:** This function's parameters are positional, and must be specified in the sequence shown in the syntax below. When specifying a parameter, use 'null' as a placeholder for any unspecified parameters. ",
+                " For example, to specify `sorting`, call `listFolders(null, sorting, null)`." ],
             "links": [],
             "examples":
               [ { "title": "List folders in a specified folder",
@@ -769,7 +779,7 @@
                       "};",
                       "",
                       "export function myListFoldersFunction() {",
-                      "  return mediaManager.listFolders(filters)",
+                      "  return mediaManager.listFolders(filters, null, null)",
                       "    .then((myFolders) => {",
                       "      const folderName = myFolders[0].folderName;",
                       "      const updatedDate = myFolders[1]._updatedDate;",
@@ -1027,7 +1037,7 @@
   "messages":
     [ { "name": "File",
         "locations":
-          [ { "lineno": 144,
+          [ { "lineno": 137,
               "filename": "types.js" } ],
         "docs":
           { "summary": "An object containing information about the file that was listed.",
@@ -1043,7 +1053,7 @@
                       "};",
                       "",
                       "export function myListFilesFunction() {",
-                      "  return mediaManager.listFiles(filters)",
+                      "  return mediaManager.listFiles(filters, null, null)",
                       "    .then((myFiles) => {",
                       "      const originalFileName = myFiles[0].originalFileName;",
                       "      const fileName = myFiles[1].fileName;",
@@ -1297,7 +1307,7 @@
         "extra":
           {  },
         "labels":
-          [ "new" ] },
+          [ "changed" ] },
       { "name": "FileFilterOptions",
         "locations":
           [ { "lineno": 12,
@@ -1323,11 +1333,10 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "new" ] },
+        "labels": [] },
       { "name": "FileInfo",
         "locations":
-          [ { "lineno": 99,
+          [ { "lineno": 92,
               "filename": "types.js" } ],
         "docs":
           { "summary": "An object containing information about the file that was uploaded.",
@@ -1397,8 +1406,7 @@
               "doc": "Date the file was updated." } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "FolderFilterOptions",
         "locations":
           [ { "lineno": 27,
@@ -1416,11 +1424,10 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "new" ] },
+        "labels": [] },
       { "name": "FolderInfo",
         "locations":
-          [ { "lineno": 181,
+          [ { "lineno": 174,
               "filename": "types.js" } ],
         "docs":
           { "summary": "An object containing information about the folder.",
@@ -1448,11 +1455,10 @@
               "doc": "Date the folder was updated." } ],
         "extra":
           {  },
-        "labels":
-          [ "new" ] },
+        "labels": [] },
       { "name": "MediaOptions",
         "locations":
-          [ { "lineno": 54,
+          [ { "lineno": 47,
               "filename": "types.js" } ],
         "docs":
           { "summary": "An object containing information about the media options of a file to upload.",
@@ -1617,11 +1623,10 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "MetadataOptions",
         "locations":
-          [ { "lineno": 77,
+          [ { "lineno": 70,
               "filename": "types.js" } ],
         "docs":
           { "summary": "An object containing information about the metadata options of a file to upload.",
@@ -1817,6 +1822,29 @@
         "extra":
           {  },
         "labels":
+          [ "removed" ] },
+      { "name": "PagingOptions",
+        "locations":
+          [ { "lineno": 40,
+              "filename": "types.js" } ],
+        "docs":
+          { "summary": "Paging options.",
+            "links": [],
+            "examples": [],
+            "extra":
+              {  } },
+        "members":
+          [ { "name": "limit",
+              "type": "number",
+              "doc": "Amount of records to retrieve.",
+              "optional": true },
+            { "name": "skip",
+              "type": "number",
+              "doc": "Number of records to skip.",
+              "optional": true } ],
+        "extra":
+          {  },
+        "labels":
           [ "new" ] },
       { "name": "SortOptions",
         "locations":
@@ -1840,7 +1868,7 @@
         "extra":
           {  },
         "labels":
-          [ "new" ] },
+          [ "removed" ] },
       { "name": "SortingOptions",
         "locations":
           [ { "lineno": 33,
@@ -1862,8 +1890,7 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "new" ] },
+        "labels": [] },
       { "name": "UploadOptions",
         "locations":
           [ { "lineno": 1,
@@ -2031,7 +2058,7 @@
         "labels": [] },
       { "name": "UploadUrl",
         "locations":
-          [ { "lineno": 194,
+          [ { "lineno": 187,
               "filename": "types.js" } ],
         "docs":
           { "summary": "An object containing information about an upload URL.",


### PR DESCRIPTION
…ssue detected

changes:
Service wix-media-backend.MediaManager operation listFiles has changed param filters doc
Service wix-media-backend.MediaManager operation listFiles has changed param name from sort to sorting
Service wix-media-backend.MediaManager operation listFiles has changed param sorting doc
Service wix-media-backend.MediaManager operation listFiles has changed param name from pagination to paging
Service wix-media-backend.MediaManager operation listFiles has changed param paging type
Service wix-media-backend.MediaManager operation listFiles has changed param paging doc
Service wix-media-backend.MediaManager operation listFiles has changed param paging doc
Service wix-media-backend.MediaManager operation listFiles has changed description
Service wix-media-backend.MediaManager operation listFiles.examples[0] has changed body
Service wix-media-backend.MediaManager operation listFolders has changed param filters doc
Service wix-media-backend.MediaManager operation listFolders has changed param name from sort to sorting
Service wix-media-backend.MediaManager operation listFolders has changed param sorting type
Service wix-media-backend.MediaManager operation listFolders has changed param sorting doc
Service wix-media-backend.MediaManager operation listFolders has changed param name from pagination to paging
Service wix-media-backend.MediaManager operation listFolders has changed param paging type
Service wix-media-backend.MediaManager operation listFolders has changed param paging doc
Service wix-media-backend.MediaManager operation listFolders has changed param paging doc
Service wix-media-backend.MediaManager operation listFolders has changed description
Service wix-media-backend.MediaManager operation listFolders.examples[0] has changed body
Service wix-media-backend.MediaManager message File.examples[0] has changed body
Service wix-media-backend.MediaManager message PaginationOptions wa ...