### PR TITLE
DocWorks for wix-events-backend - 2 changes detected, but 3 issue det…

### DIFF
--- a/wix-events-backend/wix-events-backend/WixEvents.service.json
+++ b/wix-events-backend/wix-events-backend/WixEvents.service.json
@@ -1310,7 +1310,7 @@
           { "type": "wix-events-backend.WixEvents.EventsQueryBuilder",
             "doc": "Contains functionality for refining a Wix events query.\nThe `EventsQueryBuilder` functions enable you to run, sort, filter, and control\nwhich results a query returns.\n\nTypically, you build a query using any of the event query functions,\nrefine the query by chaining `EventsQueryBuilder` functions, and then execute the\nquery by chaining the [`find()`](#find) function.\n\nFor example, the following code returns the first 5 upcoming Wix events created by\na given event manager, including scheduled events and events that \nhave started. The events are listed in ascending\norder by the event's start date.\n\n```javascript\nimport { wixEvents } from 'wix-events-backend';\n\nwixEvents.queryEvents()\n  .eq(\"createdBy\", \"4c47c608-cfa8-4037-93ac-738f09560ed3\")\n  .hasSome(\"status\", [\"SCHEDULED\", \"STARTED\"])\n  .ascending(\"scheduling.startDate\")\n  .limit(5)\n  .find()\n  .then( (results) => {\n    console.log(results.items);\n  } );\n```" },
         "locations":
-          [ { "lineno": 847,
+          [ { "lineno": 850,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Creates a query to retrieve a list of Wix events.",
@@ -2345,7 +2345,7 @@
         "labels": [] },
       { "name": "QueryOptions",
         "locations":
-          [ { "lineno": 832,
+          [ { "lineno": 835,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Options to use when performing a query or query count.",
@@ -2362,7 +2362,7 @@
         "members":
           [ { "name": "suppressAuth",
               "type": "boolean",
-              "doc": "Prevents permission checks from running for the [`find()`](wix-events-backend.WixEvents/eventsquerybuilder/find) operation. Defaults to `false`.",
+              "doc": "When `true`, prevents permission checks from running for the operation. Defaults to `false`.",
               "optional": true } ],
         "extra":
           {  },

--- a/wix-events-backend/wix-events-backend/WixEvents/EventsQueryBuilder.service.json
+++ b/wix-events-backend/wix-events-backend/WixEvents/EventsQueryBuilder.service.json
@@ -1,7 +1,8 @@
 { "name": "EventsQueryBuilder",
   "memberOf": "wix-events-backend.WixEvents",
   "mixes": [],
-  "labels": [],
+  "labels":
+    [ "changed" ],
   "location":
     { "lineno": 1,
       "filename": "event-query.js" },
@@ -818,7 +819,8 @@
         "extra":
           {  } },
       { "name": "find",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "options",
@@ -840,7 +842,9 @@
               [ "The `find()` function returns a Promise that resolves to the results found",
                 " by the query and some information about the results. The Promise is",
                 " rejected if `find()` is called with incorrect permissions or if any of the",
-                " functions used to refine the query are invalid." ],
+                " functions used to refine the query are invalid.",
+                "",
+                "> **Note:** A guest can only view their own events. You can override the permissions by setting the `suppressAuth` option to `true`." ],
             "links": [],
             "examples":
               [ { "title": "Perform a find on a query",

--- a/wix-events-backend/wix-events-backend/WixEvents/EventsQueryResult.service.json
+++ b/wix-events-backend/wix-events-backend/WixEvents/EventsQueryResult.service.json
@@ -3,7 +3,7 @@
   "mixes": [],
   "labels": [],
   "location":
-    { "lineno": 635,
+    { "lineno": 638,
       "filename": "event-query.js" },
   "docs":
     { "summary": "The results of a Wix events query, containing the retrieved items.",
@@ -23,7 +23,7 @@
         "set": false,
         "type": "number",
         "locations":
-          [ { "lineno": 750,
+          [ { "lineno": 753,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Returns the index of the current results page number.",
@@ -72,7 +72,7 @@
             "typeParams":
               [ "wix-events-backend.WixEvents.WixEvent" ] },
         "locations":
-          [ { "lineno": 646,
+          [ { "lineno": 649,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Returns the items that match the query.",
@@ -123,7 +123,7 @@
         "set": false,
         "type": "number",
         "locations":
-          [ { "lineno": 661,
+          [ { "lineno": 664,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Returns the number of items in the current results page.",
@@ -165,7 +165,7 @@
         "set": false,
         "type": "number",
         "locations":
-          [ { "lineno": 722,
+          [ { "lineno": 725,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Returns the query page size.",
@@ -207,7 +207,7 @@
         "set": false,
         "type": "wix-events-backend.WixEvents.EventsQueryBuilder",
         "locations":
-          [ { "lineno": 687,
+          [ { "lineno": 690,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Contains functionality for refining a Wix events query.",
@@ -276,7 +276,7 @@
         "set": false,
         "type": "number",
         "locations":
-          [ { "lineno": 675,
+          [ { "lineno": 678,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Returns the total number of items that match the query.",
@@ -316,7 +316,7 @@
         "set": false,
         "type": "number",
         "locations":
-          [ { "lineno": 736,
+          [ { "lineno": 739,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Returns the total number of pages the query produced.",
@@ -361,7 +361,7 @@
           { "type": "boolean",
             "doc": "`true` if there are more results." },
         "locations":
-          [ { "lineno": 814,
+          [ { "lineno": 817,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Indicates if the query has more results.",
@@ -405,7 +405,7 @@
           { "type": "boolean",
             "doc": "`true` if there are previous results." },
         "locations":
-          [ { "lineno": 824,
+          [ { "lineno": 827,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Indicates if the query has previous results.",
@@ -431,7 +431,7 @@
                   [ "wix-events-backend.WixEvents.EventsQueryResult" ] },
             "doc": "Fulfilled - The results of a Wix events query, containing the retrieved items.\nWhen you execute a query with the [`find()`](wix-events-backend.eventsquerybuilder.html#find)\nfunction, it returns a Promise that resolves to an `EventsQueryResult` object.\nThis object contains the items that match the query, information about the\nquery itself, and functions for paging through the query results." },
         "locations":
-          [ { "lineno": 768,
+          [ { "lineno": 771,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Retrieves the next page of query results.",
@@ -504,7 +504,7 @@
                   [ "wix-events-backend.WixEvents.EventsQueryResult" ] },
             "doc": "Fulfilled - The results of a Wix events query, containing the retrieved items.\nWhen you execute a query with the [`find()`](wix-events-backend.eventsquerybuilder.html#find)\nfunction, it returns a Promise that resolves to an `EventsQueryResult` object.\nThis object contains the items that match the query, information about the\nquery itself, and functions for paging through the query results." },
         "locations":
-          [ { "lineno": 792,
+          [ { "lineno": 795,
               "filename": "event-query.js" } ],
         "docs":
           { "summary": "Retrieves the previous page of query results.",


### PR DESCRIPTION
…ected

changes:
Service wix-events-backend.WixEvents.EventsQueryBuilder operation find has changed description
Service wix-events-backend.WixEvents message QueryOptions member suppressAuth has changed doc

issues:
Operation eq has an unknown param type * (event-query.js (34))
Operation ne has an unknown param type * (event-query.js (63))
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating