### PR TITLE
DocWorks for wix-media-manager-backend - 5 changes detected, but 2 is…

### DIFF
--- a/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
+++ b/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
@@ -188,7 +188,8 @@
         "extra":
           {  } },
       { "name": "getDownloadUrl",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "fileUrl",
@@ -229,8 +230,7 @@
                 "",
                 ">**Notes:** ",
                 "> + The download URL with the token is valid for a single file download only. `getDownloadUrl()` must be called for each file that you want to download.",
-                "> + This function's parameters are positional, and must be specified in the sequence shown in the syntax below. When specifying a parameter, use 'null' as a placeholder for any unspecified parameters. ",
-                " For example, to specify `downloadedFileName` only, call `getDownloadUrl(fileUrl, null, downloadedFileName, null)`." ],
+                "> + This function's parameters are positional, and must be specified in the sequence shown in the syntax below. When specifying a parameter, use `null` as a placeholder for any unspecified parameters. For example, to specify `downloadedFileName` only, call `getDownloadUrl(fileUrl, null, downloadedFileName, null)`." ],
             "links": [],
             "examples":
               [ { "title": "Get a temporary download URL",
@@ -401,9 +401,10 @@
                       "",
                       "/* Returns a promise that resolves to:",
                       " * https://download-files.wix.com/_api/download/file?downloadToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9eyJpc3MiO...",
-                      " */" ],
+                      " */",
+                      "" ],
                   "extra":
-                    {  } } ],
+                    { "description": "<span style=\"color: #FF5252\">This example uses a deprecated function.</span>" } } ],
             "extra":
               {  } },
         "extra":
@@ -737,7 +738,8 @@
         "extra":
           {  } },
       { "name": "listFiles",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "filters",
@@ -771,7 +773,7 @@
                 "",
                 " To get a list of files within a specific folder in the Media Manager, pass the folder's ID in the `parentFolderId` parameter. If no folder is specified, the `listFiles()` function returns the list of files in the root folder of the Media Manager. ",
                 "",
-                " >**Note:** This function's parameters are positional, and must be specified in the sequence shown in the syntax below. When specifying a parameter, use 'null' as a placeholder for any unspecified parameters. ",
+                " >**Note:** This function's parameters are positional, and must be specified in the sequence shown in the syntax below. When specifying a parameter, use `null` as a placeholder for any unspecified parameters. ",
                 " For example, to specify `sorting` only, call `listFiles(null, sorting, null)`." ],
             "links": [],
             "examples":
@@ -986,7 +988,8 @@
         "extra":
           {  } },
       { "name": "listFolders",
-        "labels": [],
+        "labels":
+          [ "changed" ],
         "nameParams": [],
         "params":
           [ { "name": "filters",
@@ -1020,7 +1023,7 @@
                 "",
                 " To get a list of folders within a specific folder in the Media Manager, pass the folder's ID in the `parentFolderId` parameter. If no folder is specified, the `listFolders()` function returns the list of folders in the root folder of the Media Manager.",
                 " ",
-                " >**Note:** This function's parameters are positional, and must be specified in the sequence shown in the syntax below. When specifying a parameter, use 'null' as a placeholder for any unspecified parameters. ",
+                " >**Note:** This function's parameters are positional, and must be specified in the sequence shown in the syntax below. When specifying a parameter, use `null` as a placeholder for any unspecified parameters. ",
                 " For example, to specify `sorting` only, call `listFolders(null, sorting, null)`." ],
             "links": [],
             "examples":


### PR DESCRIPTION
…sue detected

changes:
Service wix-media-backend.MediaManager operation getDownloadUrl has changed description
Service wix-media-backend.MediaManager operation getFileUrl.examples[0] has changed body
Service wix-media-backend.MediaManager operation getFileUrl.examples[0] has changed extra.description
Service wix-media-backend.MediaManager operation listFiles has changed description
Service wix-media-backend.MediaManager operation listFolders has changed description

issues:
Operation upload has an unknown param type Buffer (upload.js (1))
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating