### PR TITLE
DocWorks for editor-elements - no significant changes detected, but 6…

### DIFF
--- a/editor-elements/$w/CollapsibleTextBox.service.json
+++ b/editor-elements/$w/CollapsibleTextBox.service.json
@@ -4,8 +4,7 @@
     [ "$w.Element",
       "$w.HiddenCollapsedMixin",
       "$w.ClickableMixin" ],
-  "labels":
-    [ "new" ],
+  "labels": [],
   "location":
     { "lineno": 1,
       "filename": "CollapsibleTextBox.js" },


### PR DESCRIPTION
… issue detected

issues:
Mixin $w.HiddenCollapsedMixin not found (Breadcrumbs.js (1))
Mixin $w.ViewportMixin not found (Breadcrumbs.js (1))
Mixin $w.Element not found (CollapsibleTextBox.js (1))
Mixin $w.HiddenCollapsedMixin not found (CollapsibleTextBox.js (1))
Mixin $w.ClickableMixin not found (CollapsibleTextBox.js (1))
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating