### PR TITLE
DocWorks for wix-media-manager-backend - no significant changes detec…

### DIFF
--- a/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
+++ b/wix-media-manager-backend/wix-media-backend/MediaManager.service.json
@@ -1,8 +1,7 @@
 { "name": "MediaManager",
   "memberOf": "wix-media-backend",
   "mixes": [],
-  "labels":
-    [ "changed" ],
+  "labels": [],
   "location":
     { "lineno": 15,
       "filename": "index.js" },
@@ -2308,8 +2307,7 @@
               "optional": true } ],
         "extra":
           {  },
-        "labels":
-          [ "changed" ] },
+        "labels": [] },
       { "name": "UploadOptions",
         "locations":
           [ { "lineno": 1,


### PR DESCRIPTION
…ted, but 2 issue detected

issues:
Operation upload has an unknown param type Buffer (upload.js (1)) Browserslist: caniuse-lite is outdated. Please run: npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating