### PR TITLE
autovelo articles

### DIFF
--- a/wix-events-v2/wix-events-v2/guides/fieldsets.md
+++ b/wix-events-v2/wix-events-v2/guides/fieldsets.md
@@ -1,0 +1,72 @@
+# Fieldset
+
+Fieldset is a unified control for additional data that can be returned in the response. 
+
+## Event fieldset
+
+By default, the `event` data in the response returns `id`, `title`, `slug`, `location`, `scheduling`, `tags`, `created`, `modified`, `status`, `guestListConfig`, `instanceId`, `userId` and `language` fields. 
+The response will also include following parameters based on the fieldsets provided in the request.
+
+
+ | Fieldset                    | Fields                                         |
+ |-----------------------------|------------------------------------------------|
+ | DETAILS                     | `description`, `mainImage` and `calendarLinks` |
+ | TEXTS                       | `about`                                        |
+ | REGISTRATION                | `registration`                                 |
+ | URLS                        | `eventPageUrl`                                 |
+ | FORM                        | `form`                                         |
+ | DASHBOARD                   | `dashboard`                                    |
+ | FEED (for internal use)     | `feed` (for internal use)                      |
+ | ONLINE_CONFERENCING_SESSION | `onlineConferencing`                           |
+
+
+## Ticket definition fieldset
+ 
+By default, the `definitions` data in the response contains `id`, `price`, `free`, `name`, `limitPerCheckout`, `orderIndex` and `eventId` fields. 
+The response will also include the following parameters based on the fieldsets provided in the request.
+ 
+ | Fieldset     | Fields        |
+ |--------------|---------------|
+ | POLICY       | `policy`      |
+ | DASHBOARD    | `dashboard`   |
+
+## Order fieldset
+
+By default, the `order` data returned in the response contains `orderNumber`, `eventId`, `contactId`, `memberId`, `anonimyzed` and `fullyCheckedIn` fields. 
+The response will also include following parameters based on the fieldsets provided in the request.
+
+ | Fieldset      | Fields                                                                                                                                                                       |
+ |---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+ | DETAILS       | `reservationId`, `snapshotId`, `created`, `firstName`, `lastName`, `confirmed`, `status`, `method`, `ticketsQuantity`, `totalPrice`, `ticketsPdf`, `archived` and `fullName` |
+ | FORM          | `checkoutForm`                                                                                                                                                               |
+ | TICKETS       | `tickets`                                                                                                                                                                    |
+ | INVOICE       | `invoice`                                                                                                                                                                    |
+
+## Ticket fieldset
+
+By default, the `ticket` data in the response contains `memberId` and `anonymized` fields. 
+The response will also include following parameters based on the fieldsets provided in the request.
+
+ | Fieldset         | Fields                                                                                                                                                                                                                  |
+ |------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+ | TICKET_DETAILS   | `ticketNumber`, `orderNumber`, `ticketDefinitionId`, `name`, `price`, `free`, `policy`, `qrCode`, `checkIn`, `orderStatus`, `orderArchived`, `archived`, `orderFullName`, `ticketPdf`, `checkInUrl`  and `ticketPdfUrl` |
+ | GUEST_DETAILS    | `guestDetails`                                                                                                                                                                                                          |
+ | GUEST_FORM       | `guestDetails.form`                                                                                                                                                                                                     |
+
+## Policy fieldset
+
+By default, the `policy` data in the response contains `id`, `eventId`, `name`, `updated_date` and `sortIndex` fields. 
+The response will also include following parameters based on the fieldsets provided in the request.
+
+ | Fieldset         | Fields                         |
+ |------------------|--------------------------------|
+ | BODY             | `body`                         |
+
+## Token fieldset
+
+By default, the get tokens response contains only `token` field. 
+The response will also include following parameters based on the fieldsets provided in the request.
+
+ | Fieldset         | Fields                         |
+ |------------------|--------------------------------|
+ | POLICIES         | `policies`                     |

--- a/wix-events-v2/wix-events-v2/guides/pagination.md
+++ b/wix-events-v2/wix-events-v2/guides/pagination.md
@@ -1,0 +1,22 @@
+# Pagination
+
+The standard Wix API pagination includes:
+
+- **limit**: amount of items per response (default is `0`)
+
+- **offset**: number of items to skip
+
+The following examples:
+
+```
+?limit=100&offset=20
+```
+
+and
+
+```json
+    "limit": 100, 
+    "offset": 20 
+```
+
+Should return items 21-120 in the results.

--- a/wix-events-v2/wix-events-v2/guides/partial-updates.md
+++ b/wix-events-v2/wix-events-v2/guides/partial-updates.md
@@ -1,0 +1,61 @@
+# Partial Updates
+Most `PATCH` endpoints support partial updates via a combination of a _partial entity body_ and a `fields` parameter.
+
+## Fields parameter
+The `fields` parameter accepts a set of field paths that specifies the entity data to update. In general, the fields path begins from the root of the request body.
+
+When the `fields` parameter contains a sub-path of the entity fields, like `event` - all nested fields are included in the update: `event.title`, `event.description`, etc.
+
+When the `fields` parameter is empty, the request will modify ALL entity fields.
+
+`fields` parameter behavior follows [google.protobuf.FieldMask][google-protobuf-fieldmask] semantics.
+
+## Examples
+To update an `Event` title, and reschedule it to a later date, the request would look like this:
+```json
+{
+  "event": {
+    "title": "My event (rescheduled & relocated)",
+    "scheduleConfig": {
+      "startDate": "2032-05-16T10:00:00.000+03:00",
+      "endDate": "2032-05-16T10:30:00.000+03:00"
+    }
+  },
+  "fields": {
+    "paths": [
+      "event.title",
+      "event.scheduleConfig.startDate",
+      "event.scheduleConfig.endDate"
+    ]
+  }
+}
+```
+
+
+To erase optional fields, send an empty body and list the field(s) to update in the `fields` parameter.
+For example, to clear an event description, the request would look like this:
+```json
+{
+  "event": {},
+  "fields": {
+    "paths": [
+      "event.description"
+    ]
+  }
+}
+```
+
+When only one parameter can be updated, the `fields` parameter must still be passed.
+For example, to bulk update the `status` of multiple RSVPs to one event, the request would look like this:
+```json
+{
+  "status": "WAITING",
+  "fields": {
+     "paths": [
+       "status"
+     ]
+   }
+}
+```
+
+[google-protobuf-fieldmask]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.FieldMask


### PR DESCRIPTION
added REST articles for autovelo to Events V2:
- fieldsets
- partial-updates
- pagination (Not published in REST but linked to - Events/listTickets)
Didn't add fiter-and-sort as it is under discussion still.