### PR TITLE
Fix dev preview

### DIFF
--- a/.github/workflows/buildDevPreview.yaml
+++ b/.github/workflows/buildDevPreview.yaml
@@ -22,7 +22,7 @@ jobs:
           git config user.name "Adam Friedmann"
           git checkout -b auto-dev-preview-update-${{github.head_ref}}
           node scripts/buildDevPreviewList.mjs
-          git add .
+          git add guides/developer-preview.md
           DIFF=$(git status --porcelain)
           if [[ "$DIFF" == *"developer-preview.md"* ]]; then
             git commit -m "New Dev Preview List"

--- a/.github/workflows/syncMenuEditor.yaml
+++ b/.github/workflows/syncMenuEditor.yaml
@@ -23,13 +23,13 @@ jobs:
           git config user.name "Adam Friedmann"
           git checkout -b menu-editor-sync
           node scripts/getHiddenItems.mjs
-          git add .
+          git add scripts/hiddenItems.json
           git status --porcelain
           DIFF=$(git status --porcelain)
           if [[ "$DIFF" == *"hiddenItems.json"* ]]; then
             npm install get-all-files
             node scripts/buildDevPreviewList.mjs
-            git add .
+            git add guides/developer-preview.md
             git commit -m "Syncing with hidden items in the menu editor"
             git push --set-upstream origin menu-editor-sync --force
             echo "changes_pushed=yes" >> $GITHUB_ENV


### PR DESCRIPTION
Fixing git adds in the dev preview workflows so they don't add all the extra stuff from the npm installs.